### PR TITLE
Added --release 8 switch to CMAKE_JAVA_COMPILE_FLAGS

### DIFF
--- a/bindings/java/CMakeLists.txt
+++ b/bindings/java/CMakeLists.txt
@@ -167,7 +167,7 @@ target_link_libraries(java_workloads PUBLIC fdb_c ${JNI_LIBRARIES})
 target_link_libraries(java_workloads PRIVATE flow) # mostly for boost
 target_include_directories(java_workloads PUBLIC ${JNI_INCLUDE_DIRS})
 
-set(CMAKE_JAVA_COMPILE_FLAGS "-source" "1.8" "-target" "1.8" "-XDignore.symbol.file")
+set(CMAKE_JAVA_COMPILE_FLAGS "--release" "8" "-source" "1.8" "-target" "1.8" "-XDignore.symbol.file")
 set(CMAKE_JNI_TARGET TRUE)
 
 # build a manifest file


### PR DESCRIPTION
The current published java client binding jars throw an exception in ByteBuffer class. See https://www.morling.dev/blog/bytebuffer-and-the-dreaded-nosuchmethoderror/. This is due to the client jar being build using JDK >8. 

I'm adding the --release 8 option to the JAVA_COMPILE_FLAGS as a workaround to run in a JDK 1.8 environment.
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
